### PR TITLE
enhancement/load member from list using inertia link component to make it load faster

### DIFF
--- a/laravel/resources/js/Components/MemberSummaryCard.vue
+++ b/laravel/resources/js/Components/MemberSummaryCard.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import { Link } from '@inertiajs/vue3';
 import { TheCard, Badge, } from 'flowbite-vue'
 
 const props = defineProps({
@@ -45,20 +46,22 @@ const linkData = { member: props.member.id, tab: 1 }
 
 </script>
 <template>
-<the-card :href="route(props.linkRoute, linkData)" class="sm:w-full">
-    <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-      <span v-if="props.member.title_id">{{ props.member.title.title }}</span> {{ member_name }}
-    </h5>
+  <the-card class="sm:w-full">
+    <Link :href="route(props.linkRoute, linkData)">
+      <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+        <span v-if="props.member.title_id">{{ props.member.title.title }}</span> {{ member_name }}
+      </h5>
 
-    <div class="flex mb-3">
-      <Badge :type="badgeType" v-if="props.member.membership_status">
-        {{ props.member.membership_status.title }}</Badge>
-      <Badge type="yellow" v-else>Draft</Badge>
-      <Badge type="default">{{ props.member.membership_type.title }}</Badge>
-    </div>
+      <div class="flex mb-3">
+        <Badge :type="badgeType" v-if="props.member.membership_status">
+          {{ props.member.membership_status.title }}</Badge>
+        <Badge type="yellow" v-else>Draft</Badge>
+        <Badge type="default">{{ props.member.membership_type.title }}</Badge>
+      </div>
 
-    <p class="font-normal text-gray-700 dark:text-gray-400">
-      {{ props.member.job_title }}, {{ props.member.current_employer }}
-    </p>
+      <p class="font-normal text-gray-700 dark:text-gray-400">
+        {{ props.member.job_title }}, {{ props.member.current_employer }}
+      </p>
+    </Link>
   </the-card>
 </template>


### PR DESCRIPTION
# load member from list using inertia link component to make it load faster
<!--- Provide a general summary of your changes in the Title above -->

## Description
Named the branch bugfix but its more of an enhancement. Using inertias Link component rather than a normal href so that it doesnt reload the whole page

## Motivation and Context
Better UX
Loads faster

## How has this been tested?

1. View members list
2. Click on a card
3. Page loads immediately (not a whole page refresh)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code fulfills the acceptance criteria.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
