### PR TITLE
Feat/282-notify-member-when-application-is-accepted

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -55,3 +55,6 @@ ports:
   # project port
   - port: 8000
     onOpen: open-browser
+  # mailhog port
+  - port: 8025
+    onOpen: open-browser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,8 @@ services:
   mailhog:
     image: mailhog/mailhog
     container_name: "${PROJECT_NAME}_mailhog"
+    ports:
+      - 8025:8025
     labels:
       - "traefik.http.services.${PROJECT_NAME}_mailhog.loadbalancer.server.port=8025"
       - "traefik.http.routers.${PROJECT_NAME}_mailhog.rule=Host(`mailhog.${PROJECT_BASE_URL}`)"

--- a/laravel/app/Http/Controllers/MemberController.php
+++ b/laravel/app/Http/Controllers/MemberController.php
@@ -9,11 +9,12 @@ use App\Models\MemberMailingPreference;
 use App\Models\MemberRejectionStatus;
 use App\Models\MembershipType;
 use App\Models\Team;
-use App\Notifications\AcceptanceNotification;
-use App\Notifications\EndorsementNotification;
+use App\Notifications\AcceptedNotification;
+use App\Notifications\EndorsedNotification;
 use App\Notifications\InvoiceNotification;
 use App\Notifications\PastDueSubReminder;
 use App\Notifications\RejectionNotification;
+use App\Notifications\SubmittedNotification;
 use App\Notifications\SubReminder;
 use App\Repositories\MemberInvoicesRepository;
 use App\Repositories\MemberMembershipStatusRepository;
@@ -159,7 +160,7 @@ class MemberController extends Controller
         $users = $team->allUsers();
         foreach ($users as $user) {
             if ($team->userHasPermission($user, 'member:endorse')) {
-                $user->notify(new EndorsementNotification($member));
+                $user->notify(new SubmittedNotification($member));
             }
         }
 
@@ -197,7 +198,7 @@ class MemberController extends Controller
         $users = $team->allUsers();
         foreach ($users as $user) {
             if ($team->userHasPermission($user, 'member:accept')) {
-                $user->notify(new AcceptanceNotification($member, $this->sitaOnlineService));
+                $user->notify(new EndorsedNotification($member, $this->sitaOnlineService));
             }
         }
 

--- a/laravel/app/Http/Controllers/MemberController.php
+++ b/laravel/app/Http/Controllers/MemberController.php
@@ -253,6 +253,18 @@ class MemberController extends Controller
             );
         }
 
+        // Send acceptance notifications.
+        $team = Team::first();
+        $users = $team->allUsers();
+        foreach ($users as $user) {
+            if ($team->userHasPermission($user, 'member:endorse')) {
+                $user->notify(new AcceptedNotification($member, false));
+            }
+        }
+
+        // Notify user.
+        $member->user->notify(new AcceptedNotification($member));
+
         return redirect()->back()->with('success', 'Application Accepted');
     }
 

--- a/laravel/app/Notifications/AcceptedNotification.php
+++ b/laravel/app/Notifications/AcceptedNotification.php
@@ -8,14 +8,14 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class EndorsementNotification extends Notification implements ShouldQueue
+class AcceptedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct(public Member $member)
+    public function __construct(public Member $member, public bool $isNotifyMember = true)
     {
         //
     }
@@ -35,12 +35,19 @@ class EndorsementNotification extends Notification implements ShouldQueue
      */
     public function toMail(object $notifiable): MailMessage
     {
-        return (new MailMessage())
-            ->subject('Signup submitted')
-            ->greeting('Tālofa!')
-            ->line('A signup request has been submitted. Please review
-                for your Endorsement.')
-            ->action('View details', route('members.show', $this->member->id));
+        if ($this->isNotifyMember) {
+            return (new MailMessage())
+                ->subject('Signup Accepted')
+                ->greeting('Tālofa '.$this->member->getFullName().'!')
+                ->line('Your signup request has been accepted.')
+                ->action('View details', route('members.show', $this->member->id));
+        } else {
+            return (new MailMessage())
+                ->subject('Signup Accepted')
+                ->greeting('Tālofa!')
+                ->line('A signup request has been accepted for '.$this->member->getFullName().'.')
+                ->action('View details', route('members.show', $this->member->id));
+        }
     }
 
     /**

--- a/laravel/app/Notifications/EndorsedNotification.php
+++ b/laravel/app/Notifications/EndorsedNotification.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class AcceptanceNotification extends Notification implements ShouldQueue
+class EndorsedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/laravel/app/Notifications/SubmittedNotification.php
+++ b/laravel/app/Notifications/SubmittedNotification.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Member;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class SubmittedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(public Member $member)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage())
+            ->subject('Signup submitted')
+            ->greeting('Tālofa!')
+            ->line('A signup request has been submitted. Please review
+                for your Endorsement.')
+            ->action('View details', route('members.show', $this->member->id));
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/laravel/app/Repositories/MemberInvoicesRepository.php
+++ b/laravel/app/Repositories/MemberInvoicesRepository.php
@@ -39,7 +39,7 @@ class MemberInvoicesRepository extends Repository
         // $memberInvoice->title = $invoice->getCustomData()
         $memberInvoice->file_name = $invoice->filename;
         $memberInvoice->file_path = $path;
-        $memberInvoice->file_size = $path ? Storage::size($path) : null;
+        $memberInvoice->file_size = $path !== '' && $path !== '0' ? Storage::size($path) : null;
 
         $memberInvoice->save();
 


### PR DESCRIPTION
# Notify member when application is accepted

## Summary

* **Addition of Mailhog Port**
The '.gitpod.yml' and 'docker-compose.yml' files were adjusted to include a new port for Mailhog - an email testing tool. This change allows for improved handling of emails during the development process.

* **Renaming and Utilisation of Notification Classes**
The 'MemberController.php' file has seen changes to rename and modify how it uses notification classes. These classes, namely 'AcceptanceNotification.php' and 'EndorsementNotification.php', were renamed to 'EndorsedNotification.php', 'SubmittedNotification.php' and more. This enhances the clarity and specificity of our notification systems.

* **Creation of New Notification Classes**
New notification classes 'AcceptedNotification.php', 'EndorsedNotification.php', and 'SubmittedNotification.php' were introduced. These will help us better manage different types of notifications moving forward.

* **Handling Different File Sizes**
The 'MemberInvoicesRepository.php' file has been modified to process file sizes in a different way. This brings improvements in how we manage file data.

* **Testing For New Notification**
We have updated our testing suite - 'MemberAcceptanceTest.php' - to include tests for the newly introduced notification. This ensures our notifications work as expected, and remain reliable in delivering their intended messages.

## Description
Related to #282

## Motivation and Context
Improve UX

## How has this been tested?
1. Run `make artisan queue:work`
2. Mark a member as accepted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code fulfills the acceptance criteria.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
