### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_fixes.yml
+++ b/.github/workflows/code_fixes.yml
@@ -3,6 +3,9 @@ name: Code Fixes
 on:
   push:
 
+permissions:
+  contents: write
+
 jobs:
   php-code-styling:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sita-samoa/sita-membership/security/code-scanning/33](https://github.com/sita-samoa/sita-membership/security/code-scanning/33)

Add an explicit `permissions` block to `.github/workflows/code_fixes.yml` so the workflow does not rely on implicit defaults.  
Best single fix here (without changing behavior) is to set workflow-level permissions to:
- `contents: write` (required for the auto-commit step to push changes)

This preserves existing functionality (including committing changes) while making token scope explicit and compliant with the rule. Place the block at the top level, right after `on:` (or before `jobs:`), so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
